### PR TITLE
ci: add CodeQL security and quality scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "27 3 * * 1"  # Weekly, Monday 03:27 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Enables GitHub code scanning via CodeQL, which was previously not configured on the repo (only Dependabot was active).

## What it does
- Analyzes the Python source with the **security-and-quality** query suite
- Triggers on pushes to `main`/`develop`, PRs to `main`, and a weekly schedule
- Uploads results to the repo's **Security → Code scanning** tab

## Notes
- Uses the same pinned action major versions as the existing workflows (`actions/checkout@v7`, `github/codeql-action@v3`)
- Secret scanning + push protection were also enabled on the repo settings (no code change needed for those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)