### PR TITLE
fix: resolve CodeQL code-quality findings (with tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project and dev tools
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest

--- a/cloudx_proxy/_1password.py
+++ b/cloudx_proxy/_1password.py
@@ -1,7 +1,6 @@
 import os
 import json
 import subprocess
-from pathlib import Path
 
 def check_1password_cli() -> tuple:
     """Check if 1Password CLI is installed and authenticated.

--- a/cloudx_proxy/cli.py
+++ b/cloudx_proxy/cli.py
@@ -1,12 +1,11 @@
 import os
 import sys
-import re
 from pathlib import Path
 import click
 from . import __version__
 from .core import CloudXProxy
 from .setup import CloudXSetup
-from .colors import header, success, error as color_error, info, format_instance_id, format_hostname, format_command, secondary
+from .colors import header, error as color_error, info, format_hostname, format_command, secondary
 
 
 def detect_ssh_defaults() -> tuple:

--- a/cloudx_proxy/core.py
+++ b/cloudx_proxy/core.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-from pathlib import Path
 import boto3
 from botocore.exceptions import ClientError
 

--- a/cloudx_proxy/setup.py
+++ b/cloudx_proxy/setup.py
@@ -1,15 +1,14 @@
 import os
 import re
 import time
-import json
 import subprocess
 import platform
 from pathlib import Path
 from typing import Optional, Tuple
 import boto3
 from botocore.exceptions import ClientError
-from ._1password import check_1password_cli, check_ssh_agent, list_ssh_keys, create_ssh_key, get_vaults, save_public_key
-from .colors import header, success, error, warning, info, prompt as color_prompt, status_symbol, format_path, format_command
+from ._1password import check_1password_cli, list_ssh_keys, create_ssh_key, get_vaults, save_public_key
+from .colors import header, warning, info, prompt as color_prompt, status_symbol, format_path, format_command
 
 class CloudXSetup:
     # Define SSH key prefix as a constant
@@ -297,7 +296,7 @@ class CloudXSetup:
             # Try to create session with profile
             try:
                 session = boto3.Session(profile_name=self.profile)
-            except:
+            except Exception:
                 # Profile doesn't exist, create it
                 self.print_status(f"AWS profile '{self.profile}' not found", False, 2)
                 self.print_status("Setting up AWS profile...", None, 2)
@@ -537,17 +536,16 @@ class CloudXSetup:
             self.print_status("SSH key created successfully in 1Password", True, 2)
             
             # Save the public key to the expected location
-            if save_public_key(public_key, f"{self.ssh_key_file}.pub"):
-                self.print_status(f"Saved public key to {self.ssh_key_file}.pub", True, 2)
-                return True
-            else:
+            if not save_public_key(public_key, f"{self.ssh_key_file}.pub"):
                 self.print_status(f"Failed to save public key to {self.ssh_key_file}.pub", False, 2)
                 return False
-            
+
+            self.print_status(f"Saved public key to {self.ssh_key_file}.pub", True, 2)
+
             # Remind user to enable the key in 1Password SSH agent
             self.print_status(warning("Important: Make sure the key is enabled in 1Password's SSH agent settings"), None, 2)
             return True
-            
+
         except Exception as e:
             self.print_status(f"Error creating key in 1Password: {str(e)}", False, 2)
             return False
@@ -1241,7 +1239,6 @@ class CloudXSetup:
                         # Extract aws-env from the existing ProxyCommand if present
                         aws_env = None
                         if '--aws-env' in line:
-                            import re
                             match = re.search(r'--aws-env\s+(\S+)', line)
                             if match:
                                 aws_env = match.group(1)
@@ -1436,7 +1433,7 @@ class CloudXSetup:
             if self.ssh_config_file.exists() and system_config_path.exists():
                 try:
                     same_file = self.ssh_config_file.samefile(system_config_path)
-                except:
+                except Exception:
                     same_file = str(self.ssh_config_file) == str(system_config_path)
             else:
                 same_file = str(self.ssh_config_file) == str(system_config_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,9 @@ local_scheme = "no-local-version"
 dev = [
     "pip-audit>=2.7.0",
     "pip-licenses>=5.0.0",
+    "pytest>=8.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,146 @@
+"""Tests for cloudx_proxy.setup.
+
+These focus on the behaviour touched by the CodeQL quality cleanup:
+
+- ``_create_1password_key`` was restructured to remove an unreachable
+  statement; the "key created" path must still save the public key AND
+  surface the SSH-agent reminder before returning ``True``.
+- ``setup_aws_profile`` narrowed a bare ``except:`` to ``except Exception:``;
+  a missing profile must still be handled, while ``KeyboardInterrupt`` must
+  now propagate.
+- ``validate_instance_id`` regression coverage.
+"""
+
+import pytest
+
+from cloudx_proxy.setup import CloudXSetup
+
+
+@pytest.fixture
+def setup(tmp_path):
+    """A CloudXSetup pointed at an isolated ssh dir (no real files touched)."""
+    return CloudXSetup(
+        profile="cloudX-test-user",
+        ssh_key="testkey",
+        ssh_dir=str(tmp_path / "ssh"),
+        non_interactive=True,
+    )
+
+
+class TestValidateInstanceId:
+    @pytest.mark.parametrize("instance_id", [
+        "i-1234abcd",                    # 8 hex
+        "i-0123456789abcdef0",           # 17 hex
+        "i-ABCDEF0123456789A",           # uppercase accepted
+    ])
+    def test_valid(self, instance_id):
+        assert CloudXSetup.validate_instance_id(instance_id) is True
+
+    @pytest.mark.parametrize("instance_id", [
+        "",
+        None,
+        "i-",
+        "1234abcd",                      # missing prefix
+        "i-1234abc",                     # 7 chars
+        "i-1234abcde",                   # 10 chars (neither 8 nor 17)
+        "i-0123456789abcdef0g",          # non-hex char
+        "i-0123456789abcdefg",           # 17 chars but non-hex
+    ])
+    def test_invalid(self, instance_id):
+        assert CloudXSetup.validate_instance_id(instance_id) is False
+
+
+class TestCreate1PasswordKey:
+    """Covers the restructured (previously unreachable) success path."""
+
+    def _install_stubs(self, monkeypatch, setup, *, create_success=True,
+                        save_success=True):
+        import cloudx_proxy.setup as setup_mod
+
+        calls = {"saved": [], "reminded": False}
+
+        monkeypatch.setattr(setup_mod, "list_ssh_keys", lambda: [])
+        monkeypatch.setattr(
+            setup_mod, "get_vaults",
+            lambda: [{"id": "vault-1", "name": "Private"}],
+        )
+        monkeypatch.setattr(
+            setup_mod, "create_ssh_key",
+            lambda title, vault: (create_success, "ssh-ed25519 AAAA...", "item-1"),
+        )
+
+        def fake_save(public_key, path):
+            calls["saved"].append((public_key, path))
+            return save_success
+
+        monkeypatch.setattr(setup_mod, "save_public_key", fake_save)
+
+        # Detect the reminder line (previously dead code after the returns).
+        orig_print_status = setup.print_status
+
+        def tracking_print_status(message, status=None, indent=0):
+            if "enabled in 1Password's SSH agent" in message:
+                calls["reminded"] = True
+            return orig_print_status(message, status, indent)
+
+        monkeypatch.setattr(setup, "print_status", tracking_print_status)
+
+        setup.op_vault = "Private"
+        return calls
+
+    def test_success_saves_key_and_shows_reminder(self, monkeypatch, setup):
+        calls = self._install_stubs(monkeypatch, setup)
+
+        result = setup._create_1password_key()
+
+        assert result is True
+        assert len(calls["saved"]) == 1, "public key should be saved exactly once"
+        assert calls["saved"][0][1].endswith("testkey.pub")
+        assert calls["reminded"], "SSH-agent reminder must be shown (was unreachable)"
+
+    def test_save_failure_returns_false_without_reminder(self, monkeypatch, setup):
+        calls = self._install_stubs(monkeypatch, setup, save_success=False)
+
+        result = setup._create_1password_key()
+
+        assert result is False
+        assert calls["reminded"] is False
+
+    def test_create_failure_returns_false(self, monkeypatch, setup):
+        calls = self._install_stubs(monkeypatch, setup, create_success=False)
+
+        result = setup._create_1password_key()
+
+        assert result is False
+        assert calls["saved"] == [], "should not attempt to save when creation failed"
+
+
+class TestSetupAwsProfileExceptionHandling:
+    """The bare except was narrowed to Exception (issue #2 in CodeQL)."""
+
+    def test_missing_profile_is_handled(self, monkeypatch, setup):
+        import cloudx_proxy.setup as setup_mod
+
+        def boom(*args, **kwargs):
+            raise Exception("profile not found")
+
+        monkeypatch.setattr(setup_mod.boto3, "Session", boom)
+        # The recovery path shells out to `aws configure`; stub it so nothing
+        # real runs. Session then raises again and the outer handler returns.
+        monkeypatch.setattr(setup_mod.subprocess, "run", lambda *a, **k: None)
+
+        # Should not raise (Exception is caught); returns a bool.
+        result = setup.setup_aws_profile()
+        assert isinstance(result, bool)
+
+    def test_keyboard_interrupt_propagates(self, monkeypatch, setup):
+        import cloudx_proxy.setup as setup_mod
+
+        def interrupt(*args, **kwargs):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(setup_mod.boto3, "Session", interrupt)
+
+        # Previously a bare `except:` would have swallowed this.
+        with pytest.raises(KeyboardInterrupt):
+            setup.setup_aws_profile()

--- a/uv.lock
+++ b/uv.lock
@@ -195,6 +195,7 @@ dependencies = [
 dev = [
     { name = "pip-audit" },
     { name = "pip-licenses" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -207,6 +208,7 @@ requires-dist = [
 dev = [
     { name = "pip-audit", specifier = ">=2.7.0" },
     { name = "pip-licenses", specifier = ">=5.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
 ]
 
 [[package]]
@@ -244,6 +246,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +273,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -472,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -511,6 +543,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves the code-quality alerts surfaced by the new CodeQL scan, **backed by a test suite** since users rely on this tool. Nothing goes to `main` until CI (pytest on Python 3.10–3.13) is green and this PR is reviewed.

## CodeQL findings addressed
| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 4 | warning | Unreachable statement in `_create_1password_key` | Restructured so the SSH-agent reminder actually runs before `return True` |
| 2, 3 | note | Bare `except:` handles `BaseException` | Narrowed to `except Exception:` so `KeyboardInterrupt`/`SystemExit` propagate |
| 5 | note | Repeated `import re` | Removed the redundant nested import |
| 6–12 | note | Unused imports | Removed (`json`, `check_ssh_agent`, `success`, `error`, `re`, `format_instance_id`, `Path`) |

**Alert #1 (high, "clear-text logging of sensitive data") is a false positive** — the flagged strings contain the product name **1Password**, not a real password. Recommend dismissing it as "false positive" in the Security tab.

## Tests added (`tests/test_setup.py`)
- `_create_1password_key`: success path saves the key **and** shows the reminder. This test **fails against the old unreachable-code version** (verified locally) and passes against the fix — it genuinely guards the behaviour change.
- `setup_aws_profile`: a missing profile is still handled, but `KeyboardInterrupt` now propagates (verifies the narrowed `except`).
- `validate_instance_id`: valid/invalid regression cases.

16 tests, all passing locally.

## CI
New `.github/workflows/test.yml` runs `pytest` on Python 3.10–3.13 for pushes and PRs to `main`/`develop`.

## Notes
- No functional/user-facing behaviour change except the (previously dead) 1Password reminder now displays as originally intended.
- `pytest` added to the `dev` dependency group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)